### PR TITLE
fix: change package.json publishConfig from restricted to public

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     ]
   },
   "publishConfig": {
-    "access": "restricted"
+    "access": "public"
   },
   "release": {
     "branches": [


### PR DESCRIPTION
The package.json configs prevented me from publishing this as an npm package publicly. I fixed it. 