### PR TITLE
refactor: renamed the npm package to @voltz-protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 1. Anywhere -> Ensure `yalc` is installed `yarn global add yalc`
 2. SDK -> Run `yarn build-release` (this prepares the JS build files)
 3. SDK -> Run `yalc publish`
-4. Another repo -> In the dependent repository, run `yalc add @voltz/v1-sdk`
-5. To update another repo -> run `yalc update @voltz/v1-sdk`
+4. Another repo -> In the dependent repository, run `yalc add @voltz-protocol/v1-sdk`
+5. To update another repo -> run `yalc update @voltz-protocol/v1-sdk`
 
 # Run test functions
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@voltz/v1-sdk",
+  "name": "@voltz-protocol/v1-sdk",
   "version": "1.0.0",
   "description": "A TypeScript wrapper for the Voltz smart contract",
   "main": "dist/index.js",


### PR DESCRIPTION
Had to rename the package to @voltz-protocol/v1-sdk since that was causing the issue with the publishing. 