### PR TITLE
feat: infer periphery address from factory

### DIFF
--- a/src/entities/amm.ts
+++ b/src/entities/amm.ts
@@ -62,7 +62,6 @@ export type AMMConstructorArgs = {
   provider?: providers.Provider;
   environment: string;
   factoryAddress: string;
-  peripheryAddress: string;
   marginEngineAddress: string;
   fcmAddress: string;
   rateOracle: RateOracle;
@@ -203,7 +202,6 @@ class AMM {
   public readonly provider?: providers.Provider;
   public readonly environment: string;
   public readonly factoryAddress: string;
-  public readonly peripheryAddress: string;
   public readonly marginEngineAddress: string;
   public readonly fcmAddress: string;
   public readonly rateOracle: RateOracle;
@@ -225,7 +223,6 @@ class AMM {
     provider,
     environment,
     factoryAddress,
-    peripheryAddress,
     marginEngineAddress,
     fcmAddress,
     rateOracle,
@@ -244,7 +241,6 @@ class AMM {
     this.provider = provider || signer?.provider;
     this.environment = environment;
     this.factoryAddress = factoryAddress;
-    this.peripheryAddress = peripheryAddress;
     this.marginEngineAddress = marginEngineAddress;
     this.fcmAddress = fcmAddress;
     this.rateOracle = rateOracle;
@@ -334,7 +330,10 @@ class AMM {
 
     const scaledNotional = this.scale(notional);
 
-    const peripheryContract = peripheryFactory.connect(this.peripheryAddress, this.signer);
+    const factoryContract = factoryFactory.connect(this.factoryAddress, this.signer);
+    const peripheryAddress = await factoryContract.periphery();
+
+    const peripheryContract = peripheryFactory.connect(peripheryAddress, this.signer);
     const swapPeripheryParams: SwapPeripheryParams = {
       marginEngine: this.marginEngineAddress,
       isFT,
@@ -471,7 +470,10 @@ class AMM {
       }
     }
 
-    const peripheryContract = peripheryFactory.connect(this.peripheryAddress, this.signer);
+    const factoryContract = factoryFactory.connect(this.factoryAddress, this.signer);
+    const peripheryAddress = await factoryContract.periphery();
+
+    const peripheryContract = peripheryFactory.connect(peripheryAddress, this.signer);
     const scaledNotional = this.scale(notional);
 
     let swapPeripheryParams: SwapPeripheryParams;
@@ -561,7 +563,10 @@ class AMM {
     const { closestUsableTick: tickUpper } = this.closestTickAndFixedRate(fixedLow);
     const { closestUsableTick: tickLower } = this.closestTickAndFixedRate(fixedHigh);
 
-    const peripheryContract = peripheryFactory.connect(this.peripheryAddress, this.signer);
+    const factoryContract = factoryFactory.connect(this.factoryAddress, this.signer);
+    const peripheryAddress = await factoryContract.periphery();
+
+    const peripheryContract = peripheryFactory.connect(peripheryAddress, this.signer);
     const scaledNotional = this.scale(notional);
     const mintOrBurnParams: MintOrBurnParams = {
       marginEngine: this.marginEngineAddress,
@@ -640,7 +645,10 @@ class AMM {
     const { closestUsableTick: tickUpper } = this.closestTickAndFixedRate(fixedLow);
     const { closestUsableTick: tickLower } = this.closestTickAndFixedRate(fixedHigh);
 
-    const peripheryContract = peripheryFactory.connect(this.peripheryAddress, this.signer);
+    const factoryContract = factoryFactory.connect(this.factoryAddress, this.signer);
+    const peripheryAddress = await factoryContract.periphery();
+
+    const peripheryContract = peripheryFactory.connect(peripheryAddress, this.signer);
     const _notional = this.scale(notional);
 
     let mintOrBurnParams: MintOrBurnParams;
@@ -732,7 +740,10 @@ class AMM {
     const { closestUsableTick: tickUpper } = this.closestTickAndFixedRate(fixedLow);
     const { closestUsableTick: tickLower } = this.closestTickAndFixedRate(fixedHigh);
 
-    const peripheryContract = peripheryFactory.connect(this.peripheryAddress, this.signer);
+    const factoryContract = factoryFactory.connect(this.factoryAddress, this.signer);
+    const peripheryAddress = await factoryContract.periphery();
+
+    const peripheryContract = peripheryFactory.connect(peripheryAddress, this.signer);
 
     const _notional = this.scale(notional);
 
@@ -805,7 +816,11 @@ class AMM {
     else {
       scaledMarginDelta = this.scale(marginDelta);
     }
-    const peripheryContract = peripheryFactory.connect(this.peripheryAddress, this.signer);
+
+    const factoryContract = factoryFactory.connect(this.factoryAddress, this.signer);
+    const peripheryAddress = await factoryContract.periphery();
+
+    const peripheryContract = peripheryFactory.connect(peripheryAddress, this.signer);
 
     await peripheryContract.callStatic.updatePositionMargin(
       this.marginEngineAddress,
@@ -900,7 +915,10 @@ class AMM {
     const { closestUsableTick: tickUpper } = this.closestTickAndFixedRate(fixedLow);
     const { closestUsableTick: tickLower } = this.closestTickAndFixedRate(fixedHigh);
 
-    const peripheryContract = peripheryFactory.connect(this.peripheryAddress, this.signer);
+    const factoryContract = factoryFactory.connect(this.factoryAddress, this.signer);
+    const peripheryAddress = await factoryContract.periphery();
+
+    const peripheryContract = peripheryFactory.connect(peripheryAddress, this.signer);
 
     await peripheryContract.callStatic.settlePositionAndWithdrawMargin(
       this.marginEngineAddress,
@@ -973,7 +991,10 @@ class AMM {
     }
     const scaledNotional = this.scale(notional);
 
-    const peripheryContract = peripheryFactory.connect(this.peripheryAddress, this.signer);
+    const factoryContract = factoryFactory.connect(this.factoryAddress, this.signer);
+    const peripheryAddress = await factoryContract.periphery();
+
+    const peripheryContract = peripheryFactory.connect(peripheryAddress, this.signer);
 
     let tickBefore = await peripheryContract.getCurrentTick(this.marginEngineAddress);
     let tickAfter = 0;
@@ -1139,7 +1160,10 @@ class AMM {
 
     const scaledNotional = this.scale(notionalToUnwind);
 
-    const peripheryContract = peripheryFactory.connect(this.peripheryAddress, this.signer);
+    const factoryContract = factoryFactory.connect(this.factoryAddress, this.signer);
+    const peripheryAddress = await factoryContract.periphery();
+
+    const peripheryContract = peripheryFactory.connect(peripheryAddress, this.signer);
 
     let tickBefore = await peripheryContract.getCurrentTick(this.marginEngineAddress);
     let tickAfter = 0;
@@ -1382,8 +1406,11 @@ class AMM {
     const signerAddress = await this.signer.getAddress();
     const tokenAddress = this.underlyingToken.id;
     const token = tokenFactory.connect(tokenAddress, this.signer);
+    
+    const factoryContract = factoryFactory.connect(this.factoryAddress, this.signer);
+    const peripheryAddress = await factoryContract.periphery();
 
-    const allowance = await token.allowance(signerAddress, this.peripheryAddress);
+    const allowance = await token.allowance(signerAddress, peripheryAddress);
 
     return allowance.gte(TresholdApprovalBn);
   }
@@ -1405,9 +1432,12 @@ class AMM {
     const tokenAddress = this.underlyingToken.id;
     const token = tokenFactory.connect(tokenAddress, this.signer);
 
-    const estimatedGas = await token.estimateGas.approve(this.peripheryAddress, MaxUint256Bn);
+    const factoryContract = factoryFactory.connect(this.factoryAddress, this.signer);
+    const peripheryAddress = await factoryContract.periphery();
 
-    const approvalTransaction = await token.approve(this.peripheryAddress, MaxUint256Bn, {
+    const estimatedGas = await token.estimateGas.approve(peripheryAddress, MaxUint256Bn);
+
+    const approvalTransaction = await token.approve(peripheryAddress, MaxUint256Bn, {
       gasLimit: getGasBuffer(estimatedGas)
     });
 
@@ -1596,8 +1626,10 @@ class AMM {
     if (!this.provider) {
       throw new Error('Blockchain not connected');
     }
+    const factoryContract = factoryFactory.connect(this.factoryAddress, this.provider);
+    const peripheryAddress = await factoryContract.periphery();
 
-    const peripheryContract = peripheryFactory.connect(this.peripheryAddress, this.provider);
+    const peripheryContract = peripheryFactory.connect(peripheryAddress, this.provider);
     const currentTick = await peripheryContract.callStatic.getCurrentTick(this.marginEngineAddress);
     const apr = tickToFixedRate(currentTick).toNumber();
 
@@ -2089,7 +2121,10 @@ class AMM {
       throw new Error('Wallet not connected');
     }
 
-    const peripheryContract = peripheryFactory.connect(this.peripheryAddress, this.signer);
+    const factoryContract = factoryFactory.connect(this.factoryAddress, this.signer);
+    const peripheryAddress = await factoryContract.periphery();
+
+    const peripheryContract = peripheryFactory.connect(peripheryAddress, this.signer);
     const marginEngineContract = marginEngineFactory.connect(this.marginEngineAddress, this.signer);
 
     const vammAddress = await marginEngineContract.vamm();
@@ -2129,7 +2164,10 @@ class AMM {
       throw new Error('Blockchain not connected');
     }
 
-    const peripheryContract = peripheryFactory.connect(this.peripheryAddress, this.provider);
+    const factoryContract = factoryFactory.connect(this.factoryAddress, this.provider);
+    const peripheryAddress = await factoryContract.periphery();
+
+    const peripheryContract = peripheryFactory.connect(peripheryAddress, this.provider);
     const marginEngineContract = marginEngineFactory.connect(this.marginEngineAddress, this.provider);
 
     const vammAddress = await marginEngineContract.vamm();


### PR DESCRIPTION
- The periphery contract address is now inferred through the factory viewable periphery() function which returns the periphery contract address