### PR TITLE
fix: update base metadat uri from subgraph

### DIFF
--- a/src/entities/communitySbt.ts
+++ b/src/entities/communitySbt.ts
@@ -106,7 +106,7 @@ class SBT {
         if(!rootEntity) {
             throw new Error('No root found')
         }
-        const metadataUri = `ipfs:${String.fromCharCode(47)}${String.fromCharCode(47)}${rootEntity.baseMetadataUri}${String.fromCharCode(47)}${badgeType}.json`;
+        const metadataUri = `${rootEntity.baseMetadataUri}${badgeType}.json`;
         const leafInfo = {
             account: owner,
             metadataURI: metadataUri
@@ -163,7 +163,7 @@ class SBT {
             if(!rootEntity) {
                 continue;
             }
-            const metadataUri = `ipfs:${String.fromCharCode(47)}${String.fromCharCode(47)}${rootEntity.baseMetadataUri}${String.fromCharCode(47)}${badge.badgeType}.json`;
+            const metadataUri = `${rootEntity.baseMetadataUri}${badge.badgeType}.json`;
             const leafInfo: LeafInfo = {
                 account: owner,
                 metadataURI: metadataUri

--- a/src/utils/communitySbt/getSubgraphLeaves.ts
+++ b/src/utils/communitySbt/getSubgraphLeaves.ts
@@ -52,7 +52,7 @@ export type LeafEntry = {
             const props = entry.id.split("#");
             const address = props[0];
 
-            const metadataURI = `ipfs:${String.fromCharCode(47)}${String.fromCharCode(47)}${baseMetadataUri}${String.fromCharCode(47)}${badgeType}.json`;
+            const metadataURI = `${baseMetadataUri}${badgeType}.json`;
 
             const snpashotEntry: LeafEntry = {
             owner: address,


### PR DESCRIPTION
Fix metadata uri  because it now comes from subgraph as `ipfs://<CID>/`