### PR TITLE
fix: empty subgraph badges array

### DIFF
--- a/src/entities/communitySbt.ts
+++ b/src/entities/communitySbt.ts
@@ -288,14 +288,10 @@ class SBT {
                     id: id,
                 },
             });
-      
-            if (!data?.data?.seasonUser) {
-                return [];// empty array
-            }
 
             const nonProgBadges = await this.getNonProgramaticBadges(userId, dbUrl);
       
-            const subgraphBadges = data.data.seasonUser.badges as SubgraphBadgeResponse[];
+            const subgraphBadges = (data?.data?.seasonUser ? data.data.seasonUser.badges : []) as SubgraphBadgeResponse[];
             let badgesResponse : BadgeResponse[] = [];
             for (const badge of subgraphBadges) {
                 if (parseInt(badge.awardedTimestamp) > 0) {
@@ -419,6 +415,7 @@ class SBT {
         const badges: NonProgramaticBadgeResponse[] = resp.data.badges;
         badges.forEach((entry) => {
             const badgeType = NON_PROGRAMATIC_BADGES_VARIANT[entry.badge];
+            
             if(badgeType) {
                 badgeResponseRecord[badgeType] = {
                     id: `${userId}#${badgeType}#1`,

--- a/src/utils/communitySbt/helpers.ts
+++ b/src/utils/communitySbt/helpers.ts
@@ -1,4 +1,5 @@
 import { Bytes, ethers } from "ethers";
+import { NON_SUBGRAPH_BADGES_SEASONS, TOP_BADGES_VARIANT } from "../../entities/communitySbt";
 import { CommunitySBT__factory } from "../../typechain-sbt";
 
 export function getBadgeTypeFromMetadataUri(metadataURI: string) : number {
@@ -36,6 +37,11 @@ export function getEtherscanURL(network: string, apiKey: string, userAddress: st
     }
 }
 
+export function getTopBadgeType(season: number, isTrader: boolean): string | undefined {
+    const actor = isTrader ? 'trader': 'liquidityProvider'
+    return NON_SUBGRAPH_BADGES_SEASONS[season].find((b) => TOP_BADGES_VARIANT[actor].includes(b));
+}
+
 /**
  * "Convert seconds to milliseconds, but only if the input is a number and not zero."
  *
@@ -48,4 +54,4 @@ export function getEtherscanURL(network: string, apiKey: string, userAddress: st
     }
   
     return seconds * 1000;
-  };
+};


### PR DESCRIPTION
Fixed issue that blocked non-prog badges from showing up if you don't have any other programmatic badges in the subgraph