### PR TITLE
Feat/deposit pending

### DIFF
--- a/src/ABIs/MellowMultiVaultRouterABI.json
+++ b/src/ABIs/MellowMultiVaultRouterABI.json
@@ -150,7 +150,26 @@
             "type": "function"
         },
         {
-            "inputs": [],
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "index",
+                    "type": "uint256"
+                }
+            ],
+            "name": "deprecateVault",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "index",
+                    "type": "uint256"
+                }
+            ],
             "name": "getBatchedDeposits",
             "outputs": [
                 {
@@ -161,9 +180,9 @@
                             "type": "address"
                         },
                         {
-                            "internalType": "uint256[]",
-                            "name": "amounts",
-                            "type": "uint256[]"
+                            "internalType": "uint256",
+                            "name": "amount",
+                            "type": "uint256"
                         }
                     ],
                     "internalType": "struct IMellowMultiVaultRouter.BatchedDeposit[]",
@@ -230,6 +249,25 @@
             "type": "function"
         },
         {
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "index",
+                    "type": "uint256"
+                }
+            ],
+            "name": "isVaultDeprecated",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
             "inputs": [],
             "name": "owner",
             "outputs": [
@@ -253,6 +291,19 @@
                 }
             ],
             "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "index",
+                    "type": "uint256"
+                }
+            ],
+            "name": "reactivateVault",
+            "outputs": [],
+            "stateMutability": "nonpayable",
             "type": "function"
         },
         {
@@ -292,6 +343,11 @@
         },
         {
             "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "index",
+                    "type": "uint256"
+                },
                 {
                     "internalType": "uint256",
                     "name": "batchSize",

--- a/src/entities/mellowLpRouter.ts
+++ b/src/entities/mellowLpRouter.ts
@@ -95,22 +95,22 @@ class MellowLpRouter {
 
   validateVaultIndices = (): boolean => {
     if (!this.vaultIndices.every((val, i, arr) => !i || arr[i - 1] <= val)) {
-      console.log('The vault indices array is not sorted');
+      // The vault indices array is not sorted
       return false;
     }
 
     if (this.vaultIndices.length !== new Set(this.vaultIndices).size) {
-      console.log('The vault indices array contains duplicate values');
+      // The vault indices array contains duplicate values
       return false;
     }
 
     if (this.vaultIndices.length === 0) {
-      console.log('The vault indices array is empty');
+      // The vault indices array is empty
       return false;
     }
 
     if (this.vaultIndices[0] < 0 || this.vaultIndices.slice(-1)[0] >= this.vaultsCount) {
-      console.log('The vault indices array contains out-of-range values');
+      // The vault indices array contains out-of-range values
       return false;
     }
 
@@ -119,12 +119,12 @@ class MellowLpRouter {
 
   validateWeights = (weights: number[]): boolean => {
     if (!weights.every((value) => Number.isInteger(value))) {
-      console.log('All values of default weights must be integer');
+      // All values of default weights must be integer
       return false;
     }
 
     if (weights.length !== this.vaultIndices.length) {
-      console.log('Lengths of vault indices and default weights array do not match');
+      // Lengths of vault indices and default weights array do not match
       return false;
     }
 

--- a/tests/mellowLpRouter.test.ts
+++ b/tests/mellowLpRouter.test.ts
@@ -10,6 +10,7 @@ import MellowLpRouter from '../src/entities/mellowLpRouter';
 import { abi as MellowMultiVaultRouterABI } from '../src/ABIs/MellowMultiVaultRouterABI.json';
 import { abi as Erc20RootVaultABI } from '../src/ABIs/Erc20RootVault.json';
 import { abi as WethABI } from '../src/ABIs/WethABI.json';
+import { withSigner } from './utils';
 
 const { provider } = waffle;
 let ethMellowLpRouter: MellowLpRouter;
@@ -17,7 +18,7 @@ let ethMellowLpRouter: MellowLpRouter;
 let localMellowRouterContract: Contract;
 
 const depositAmount = 10; // Set a default 10 ETH constant for use in tests;
-const MellowRouterAddress = '0x631cad693b6f0463b2c2729299fcca8731553bb4';
+const MellowRouterAddress = '0x704F6E9cB4f7e041CC89B6a49DF8EE2027a55164';
 const defaultWeights: number[] = [50, 50]; // default even split between 2 pools
 
 const signer = new Wallet(
@@ -36,7 +37,7 @@ describe('Mellow Router Test Suite', () => {
           chainId: 5,
           forking: {
             jsonRpcUrl: process.env.GOERLI_URL,
-            blockNumber: 7976620,
+            blockNumber: 7992457,
           },
         },
       ],
@@ -45,6 +46,22 @@ describe('Mellow Router Test Suite', () => {
 
   beforeEach('Setting up the suite', async () => {
     await resetNetwork();
+
+    localMellowRouterContract = new ethers.Contract(
+      MellowRouterAddress,
+      MellowMultiVaultRouterABI,
+      signer,
+    );
+
+    await withSigner(
+      network,
+      await localMellowRouterContract.owner(),
+      async (routerOwnerSigner) => {
+        await localMellowRouterContract
+          .connect(routerOwnerSigner)
+          .addVault((await localMellowRouterContract.getVaults())[0]);
+      },
+    );
 
     ethMellowLpRouter = new MellowLpRouter({
       mellowRouterAddress: MellowRouterAddress,
@@ -56,12 +73,6 @@ describe('Mellow Router Test Suite', () => {
 
     // Initialise the user so the router contract is connected with user to keep track of them as a signer for the deposits
     await ethMellowLpRouter.userInit(userWallet);
-
-    localMellowRouterContract = new ethers.Contract(
-      MellowRouterAddress,
-      MellowMultiVaultRouterABI,
-      signer,
-    );
   });
 
   describe('Deposit Scenarios', async () => {
@@ -112,18 +123,18 @@ describe('Mellow Router Test Suite', () => {
       await ethMellowLpRouter.deposit(depositAmount, weights);
 
       // Router gets the batched deposits
-      const batchedDeposit =
-        await ethMellowLpRouter.writeContracts?.mellowRouter.getBatchedDeposits();
-      expect(batchedDeposit.length).to.be.eq(1);
-      expect(batchedDeposit[0][0]).to.be.eq(userWallet.address);
-      expect(batchedDeposit[0][1][0]).to.be.eq(
-        BigNumber.from(depositAmount).mul('1000000000000000000').div(2),
-      );
-      expect(batchedDeposit[0][1][1]).to.be.eq(
-        BigNumber.from(depositAmount).mul('1000000000000000000').div(2),
-      );
-      // eslint-disable-next-line
-      console.log('Get batched deposits in router contract: ', batchedDeposit.toString());
+      for (let vaultIndex = 0; vaultIndex < 2; vaultIndex += 1) {
+        const batchedDeposit =
+          await ethMellowLpRouter.writeContracts?.mellowRouter.getBatchedDeposits(vaultIndex);
+        expect(batchedDeposit.length).to.be.eq(1);
+        expect(batchedDeposit[0][0]).to.be.eq(userWallet.address);
+        expect(batchedDeposit[0][1]).to.be.eq(
+          BigNumber.from(depositAmount).mul('1000000000000000000').div(2),
+        );
+
+        // eslint-disable-next-line
+        console.log(`Batched deposits in router for vault index ${vaultIndex}: ${batchedDeposit.toString()}`);
+      }
 
       // Make sure the user LP token balance before batch submission is 0 for each vault
       expect(
@@ -134,15 +145,16 @@ describe('Mellow Router Test Suite', () => {
         ).toString(),
       ).to.be.eq('0,0');
 
-      // Submit the batch of deposits from the router to the erc20 root vault
-      await ethMellowLpRouter.writeContracts?.mellowRouter.submitBatch(0);
+      // Submit the batch of deposits from the router to the erc20 root vaults
+      for (let vaultIndex = 0; vaultIndex < 2; vaultIndex += 1) {
+        await ethMellowLpRouter.writeContracts?.mellowRouter.submitBatch(vaultIndex, 0);
+      }
 
       // Get the user lp token balance after the router receives it from the erc20 root vault upon batch submission
       const userLpTokenBalance =
         await ethMellowLpRouter.writeContracts?.mellowRouter.getLPTokenBalances(userWallet.address);
-      expect(userLpTokenBalance[0]).to.be.closeTo(userLpTokenBalance[1], 1);
-      expect(userLpTokenBalance[0]).to.be.eq('4898906633876018356');
-      expect(userLpTokenBalance[1]).to.be.eq('4898906633876018355');
+      expect(userLpTokenBalance[0]).to.be.eq('5000000000000000000');
+      expect(userLpTokenBalance[1]).to.be.eq('5000000000000000000');
       // eslint-disable-next-line
       console.log('user LP token balance in Router: ', userLpTokenBalance.toString());
 
@@ -162,11 +174,8 @@ describe('Mellow Router Test Suite', () => {
       // eslint-disable-next-line
       console.log('Printing tvl list of all erc20 root vaults: ', tvl);
 
-      expect(tvl[0]).to.be.eq('11673207775126148888');
-      expect(tvl[1]).to.be.eq('11673207775126148888');
-
-      expect(userLpTokenBalance[0]).to.be.eq(BigNumber.from('4898906633876018356'));
-      expect(userLpTokenBalance[1]).to.be.eq(BigNumber.from('4898906633876018355'));
+      expect(tvl[0]).to.be.eq('10010000000000000000');
+      expect(tvl[1]).to.be.eq('10010000000000000000');
     });
 
     it('User deposits eth into router contract uneven split', async () => {
@@ -176,16 +185,22 @@ describe('Mellow Router Test Suite', () => {
       await ethMellowLpRouter.deposit(depositAmount, weights);
 
       // Router gets the batched deposits
-      const batchedDeposit =
-        await ethMellowLpRouter.writeContracts?.mellowRouter.getBatchedDeposits();
-      expect(batchedDeposit.length).to.be.eq(1);
-      expect(batchedDeposit[0][0]).to.be.eq(userWallet.address);
-      expect(batchedDeposit[0][1][0]).to.be.eq(
-        BigNumber.from(depositAmount).mul('1000000000000000000'),
-      );
-      expect(batchedDeposit[0][1][1]).to.be.eq(BigNumber.from(0));
-      // eslint-disable-next-line
-      console.log('Get batched deposits in router contract: ', batchedDeposit.toString());
+      for (let vaultIndex = 0; vaultIndex < 2; vaultIndex += 1) {
+        const batchedDeposit =
+          await ethMellowLpRouter.writeContracts?.mellowRouter.getBatchedDeposits(vaultIndex);
+        expect(batchedDeposit.length).to.be.eq(1 - vaultIndex);
+        if (batchedDeposit.length) {
+          expect(batchedDeposit[0][0]).to.be.eq(userWallet.address);
+          expect(batchedDeposit[0][1]).to.be.eq(
+            BigNumber.from(depositAmount)
+              .mul('1000000000000000000')
+              .mul(1 - vaultIndex),
+          );
+        }
+
+        // eslint-disable-next-line
+        console.log(`Batched deposits in router for vault index ${vaultIndex}: ${batchedDeposit.toString()}`);
+      }
 
       // Make sure the user LP token balance before batch submission is 0 for each vault
       expect(
@@ -196,13 +211,15 @@ describe('Mellow Router Test Suite', () => {
         ).toString(),
       ).to.be.eq('0,0');
 
-      // Submit the batch of deposits from the router to the erc20 root vault
-      await ethMellowLpRouter.writeContracts?.mellowRouter.submitBatch(0);
+      // Submit the batch of deposits from the router to the erc20 root vaults
+      for (let vaultIndex = 0; vaultIndex < 2; vaultIndex += 1) {
+        await ethMellowLpRouter.writeContracts?.mellowRouter.submitBatch(vaultIndex, 0);
+      }
 
       // Get the user lp token balance after the router receives it from the erc20 root vault upon batch submission
       const userLpTokenBalance =
         await ethMellowLpRouter.writeContracts?.mellowRouter.getLPTokenBalances(userWallet.address);
-      expect(userLpTokenBalance[0]).to.be.eq('9797813267752036713');
+      expect(userLpTokenBalance[0]).to.be.eq('10000000000000000000');
       expect(userLpTokenBalance[1]).to.be.eq('0');
       // eslint-disable-next-line
       console.log('user LP token balance in Router: ', userLpTokenBalance.toString());
@@ -224,11 +241,11 @@ describe('Mellow Router Test Suite', () => {
       console.log('Printing tvl list of all erc20 root vaults: ', tvl);
 
       // For each vault
-      expect(tvl[0]).to.be.eq('11673207775126148890');
-      expect(tvl[1]).to.be.eq('11673207775126148890');
+      expect(tvl[0]).to.be.eq('10010000000000000000');
+      expect(tvl[1]).to.be.eq('10010000000000000000');
 
       // For each vault
-      expect(userLpTokenBalance[0]).to.be.eq(BigNumber.from('9797813267752036713'));
+      expect(userLpTokenBalance[0]).to.be.eq(BigNumber.from('10000000000000000000'));
       expect(userLpTokenBalance[1]).to.be.eq(BigNumber.from('0'));
     });
 
@@ -237,18 +254,18 @@ describe('Mellow Router Test Suite', () => {
       await ethMellowLpRouter.deposit(depositAmount);
 
       // Router gets the batched deposits
-      const batchedDeposit =
-        await ethMellowLpRouter.writeContracts?.mellowRouter.getBatchedDeposits();
-      expect(batchedDeposit.length).to.be.eq(1);
-      expect(batchedDeposit[0][0]).to.be.eq(userWallet.address);
-      expect(batchedDeposit[0][1][0]).to.be.eq(
-        BigNumber.from(depositAmount).mul('1000000000000000000').div(2),
-      );
-      expect(batchedDeposit[0][1][1]).to.be.eq(
-        BigNumber.from(depositAmount).mul('1000000000000000000').div(2),
-      );
-      // eslint-disable-next-line
-      console.log('Get batched deposits in router contract: ', batchedDeposit.toString());
+      for (let vaultIndex = 0; vaultIndex < 2; vaultIndex += 1) {
+        const batchedDeposit =
+          await ethMellowLpRouter.writeContracts?.mellowRouter.getBatchedDeposits(vaultIndex);
+        expect(batchedDeposit.length).to.be.eq(1);
+        expect(batchedDeposit[0][0]).to.be.eq(userWallet.address);
+        expect(batchedDeposit[0][1]).to.be.eq(
+          BigNumber.from(depositAmount).mul('1000000000000000000').div(2),
+        );
+
+        // eslint-disable-next-line
+        console.log(`Batched deposits in router for vault index ${vaultIndex}: ${batchedDeposit.toString()}`);
+      }
 
       // Make sure the user LP token balance before batch submission is 0 for each vault
       expect(
@@ -259,15 +276,16 @@ describe('Mellow Router Test Suite', () => {
         ).toString(),
       ).to.be.eq('0,0');
 
-      // Submit the batch of deposits from the router to the erc20 root vault
-      await ethMellowLpRouter.writeContracts?.mellowRouter.submitBatch(0);
+      // Submit the batch of deposits from the router to the erc20 root vaults
+      for (let vaultIndex = 0; vaultIndex < 2; vaultIndex += 1) {
+        await ethMellowLpRouter.writeContracts?.mellowRouter.submitBatch(vaultIndex, 0);
+      }
 
       // Get the user lp token balance after the router receives it from the erc20 root vault upon batch submission
       const userLpTokenBalance =
         await ethMellowLpRouter.writeContracts?.mellowRouter.getLPTokenBalances(userWallet.address);
-      expect(userLpTokenBalance[0]).to.be.closeTo(userLpTokenBalance[1], 1);
-      expect(userLpTokenBalance[0]).to.be.eq('4898906633876018356');
-      expect(userLpTokenBalance[1]).to.be.eq('4898906633876018355');
+      expect(userLpTokenBalance[0]).to.be.eq('5000000000000000000');
+      expect(userLpTokenBalance[1]).to.be.eq('5000000000000000000');
       // eslint-disable-next-line
       console.log('user LP token balance in Router: ', userLpTokenBalance.toString());
 
@@ -288,18 +306,19 @@ describe('Mellow Router Test Suite', () => {
       console.log('Printing tvl list of all erc20 root vaults: ', tvl);
 
       // For each vault
-      expect(tvl[0]).to.be.eq('11673207775126148888');
-      expect(tvl[1]).to.be.eq('11673207775126148888');
+      expect(tvl[0]).to.be.eq('10010000000000000000');
+      expect(tvl[1]).to.be.eq('10010000000000000000');
 
       // For each vault
-      expect(userLpTokenBalance[0]).to.be.eq(BigNumber.from('4898906633876018356'));
-      expect(userLpTokenBalance[1]).to.be.eq(BigNumber.from('4898906633876018355'));
+      expect(userLpTokenBalance[0]).to.be.eq(BigNumber.from('5000000000000000000'));
+      expect(userLpTokenBalance[1]).to.be.eq(BigNumber.from('5000000000000000000'));
     });
 
     it('Have we scaled properly?', async () => {
       const amount = 1;
       expect(ethMellowLpRouter.scale(amount)).to.be.eq(BigNumber.from('1000000000000000000'));
     });
+
     it('Have we descaled properly?', async () => {
       const amount = BigNumber.from('1000000000000000000');
       expect(ethMellowLpRouter.descale(amount, 18)).to.be.eq(BigNumber.from('1'));
@@ -322,6 +341,7 @@ describe('Mellow Router Test Suite', () => {
           );
         }
       });
+
       it('User deposits erc20 into router with even split', async () => {
         // Check if WETH is approved to router from the beforeEach statement
         expect(await ethMellowLpRouter.isTokenApproved()).to.be.eq(true);
@@ -329,18 +349,18 @@ describe('Mellow Router Test Suite', () => {
         await ethMellowLpRouter.deposit(depositAmount);
 
         // Router gets the batched deposits
-        const batchedDeposit =
-          await ethMellowLpRouter.writeContracts?.mellowRouter.getBatchedDeposits();
-        expect(batchedDeposit.length).to.be.eq(1);
-        expect(batchedDeposit[0][0]).to.be.eq(userWallet.address);
-        expect(batchedDeposit[0][1][0]).to.be.eq(
-          BigNumber.from(depositAmount).mul('1000000000000000000').div(2),
-        );
-        expect(batchedDeposit[0][1][1]).to.be.eq(
-          BigNumber.from(depositAmount).mul('1000000000000000000').div(2),
-        );
-        // eslint-disable-next-line
-      console.log('Get batched deposits in router contract: ', batchedDeposit.toString());
+        for (let vaultIndex = 0; vaultIndex < 2; vaultIndex += 1) {
+          const batchedDeposit =
+            await ethMellowLpRouter.writeContracts?.mellowRouter.getBatchedDeposits(vaultIndex);
+          expect(batchedDeposit.length).to.be.eq(1);
+          expect(batchedDeposit[0][0]).to.be.eq(userWallet.address);
+          expect(batchedDeposit[0][1]).to.be.eq(
+            BigNumber.from(depositAmount).mul('1000000000000000000').div(2),
+          );
+
+          // eslint-disable-next-line
+          console.log(`Batched deposits in router for vault index ${vaultIndex}: ${batchedDeposit.toString()}`);
+        }
 
         // Make sure the user LP token balance before batch submission is 0 for each vault
         expect(
@@ -351,17 +371,18 @@ describe('Mellow Router Test Suite', () => {
           ).toString(),
         ).to.be.eq('0,0');
 
-        // Submit the batch of deposits from the router to the erc20 root vault
-        await ethMellowLpRouter.writeContracts?.mellowRouter.submitBatch(0);
+        // Submit the batch of deposits from the router to the erc20 root vaults
+        for (let vaultIndex = 0; vaultIndex < 2; vaultIndex += 1) {
+          await ethMellowLpRouter.writeContracts?.mellowRouter.submitBatch(vaultIndex, 0);
+        }
 
         // Get the user lp token balance after the router receives it from the erc20 root vault upon batch submission
         const userLpTokenBalance =
           await ethMellowLpRouter.writeContracts?.mellowRouter.getLPTokenBalances(
             userWallet.address,
           );
-        expect(userLpTokenBalance[0]).to.be.closeTo(userLpTokenBalance[1], 1);
-        expect(userLpTokenBalance[0]).to.be.eq('4898906633876018356');
-        expect(userLpTokenBalance[1]).to.be.eq('4898906633876018355');
+        expect(userLpTokenBalance[0]).to.be.eq('5000000000000000000');
+        expect(userLpTokenBalance[1]).to.be.eq('5000000000000000000');
         // eslint-disable-next-line
       console.log('user LP token balance in Router: ', userLpTokenBalance.toString());
 
@@ -382,12 +403,12 @@ describe('Mellow Router Test Suite', () => {
       console.log('Printing tvl list of all erc20 root vaults: ', tvl);
 
         // For each vault
-        expect(tvl[0]).to.be.eq('11673207775126148888');
-        expect(tvl[1]).to.be.eq('11673207775126148888');
+        expect(tvl[0]).to.be.eq('10010000000000000000');
+        expect(tvl[1]).to.be.eq('10010000000000000000');
 
         // For each vault
-        expect(userLpTokenBalance[0]).to.be.eq(BigNumber.from('4898906633876018356'));
-        expect(userLpTokenBalance[1]).to.be.eq(BigNumber.from('4898906633876018355'));
+        expect(userLpTokenBalance[0]).to.be.eq(BigNumber.from('5000000000000000000'));
+        expect(userLpTokenBalance[1]).to.be.eq(BigNumber.from('5000000000000000000'));
       });
 
       it('User deposits eth into router contract uneven split', async () => {
@@ -399,16 +420,22 @@ describe('Mellow Router Test Suite', () => {
         await ethMellowLpRouter.deposit(depositAmount, weights);
 
         // Router gets the batched deposits
-        const batchedDeposit =
-          await ethMellowLpRouter.writeContracts?.mellowRouter.getBatchedDeposits();
-        expect(batchedDeposit.length).to.be.eq(1);
-        expect(batchedDeposit[0][0]).to.be.eq(userWallet.address);
-        expect(batchedDeposit[0][1][0]).to.be.eq(
-          BigNumber.from(depositAmount).mul('1000000000000000000'),
-        );
-        expect(batchedDeposit[0][1][1]).to.be.eq(BigNumber.from(0));
-        // eslint-disable-next-line
-        console.log('Get batched deposits in router contract: ', batchedDeposit.toString());
+        for (let vaultIndex = 0; vaultIndex < 2; vaultIndex += 1) {
+          const batchedDeposit =
+            await ethMellowLpRouter.writeContracts?.mellowRouter.getBatchedDeposits(vaultIndex);
+          expect(batchedDeposit.length).to.be.eq(1 - vaultIndex);
+          if (batchedDeposit.length) {
+            expect(batchedDeposit[0][0]).to.be.eq(userWallet.address);
+            expect(batchedDeposit[0][1]).to.be.eq(
+              BigNumber.from(depositAmount)
+                .mul('1000000000000000000')
+                .mul(1 - vaultIndex),
+            );
+          }
+
+          // eslint-disable-next-line
+          console.log(`Batched deposits in router for vault index ${vaultIndex}: ${batchedDeposit.toString()}`);
+        }
 
         // Make sure the user LP token balance before batch submission is 0 for each vault
         expect(
@@ -419,15 +446,17 @@ describe('Mellow Router Test Suite', () => {
           ).toString(),
         ).to.be.eq('0,0');
 
-        // Submit the batch of deposits from the router to the erc20 root vault
-        await ethMellowLpRouter.writeContracts?.mellowRouter.submitBatch(0);
+        // Submit the batch of deposits from the router to the erc20 root vaults
+        for (let vaultIndex = 0; vaultIndex < 2; vaultIndex += 1) {
+          await ethMellowLpRouter.writeContracts?.mellowRouter.submitBatch(vaultIndex, 0);
+        }
 
         // Get the user lp token balance after the router receives it from the erc20 root vault upon batch submission
         const userLpTokenBalance =
           await ethMellowLpRouter.writeContracts?.mellowRouter.getLPTokenBalances(
             userWallet.address,
           );
-        expect(userLpTokenBalance[0]).to.be.eq('9797813267752036713');
+        expect(userLpTokenBalance[0]).to.be.eq('10000000000000000000');
         expect(userLpTokenBalance[1]).to.be.eq('0');
         // eslint-disable-next-line
         console.log('user LP token balance in Router: ', userLpTokenBalance.toString());
@@ -449,11 +478,11 @@ describe('Mellow Router Test Suite', () => {
         console.log('Printing tvl list of all erc20 root vaults: ', tvl);
 
         // For each vault
-        expect(tvl[0]).to.be.eq('11673207775126148890');
-        expect(tvl[1]).to.be.eq('11673207775126148890');
+        expect(tvl[0]).to.be.eq('10010000000000000000');
+        expect(tvl[1]).to.be.eq('10010000000000000000');
 
         // For each vault
-        expect(userLpTokenBalance[0]).to.be.eq(BigNumber.from('9797813267752036713'));
+        expect(userLpTokenBalance[0]).to.be.eq(BigNumber.from('10000000000000000000'));
         expect(userLpTokenBalance[1]).to.be.eq(BigNumber.from('0'));
       });
 
@@ -464,18 +493,18 @@ describe('Mellow Router Test Suite', () => {
         await ethMellowLpRouter.deposit(depositAmount);
 
         // Router gets the batched deposits
-        const batchedDeposit =
-          await ethMellowLpRouter.writeContracts?.mellowRouter.getBatchedDeposits();
-        expect(batchedDeposit.length).to.be.eq(1);
-        expect(batchedDeposit[0][0]).to.be.eq(userWallet.address);
-        expect(batchedDeposit[0][1][0]).to.be.eq(
-          BigNumber.from(depositAmount).mul('1000000000000000000').div(2),
-        );
-        expect(batchedDeposit[0][1][1]).to.be.eq(
-          BigNumber.from(depositAmount).mul('1000000000000000000').div(2),
-        );
-        // eslint-disable-next-line
-        console.log('Get batched deposits in router contract: ', batchedDeposit.toString());
+        for (let vaultIndex = 0; vaultIndex < 2; vaultIndex += 1) {
+          const batchedDeposit =
+            await ethMellowLpRouter.writeContracts?.mellowRouter.getBatchedDeposits(vaultIndex);
+          expect(batchedDeposit.length).to.be.eq(1);
+          expect(batchedDeposit[0][0]).to.be.eq(userWallet.address);
+          expect(batchedDeposit[0][1]).to.be.eq(
+            BigNumber.from(depositAmount).mul('1000000000000000000').div(2),
+          );
+
+          // eslint-disable-next-line
+          console.log(`Batched deposits in router for vault index ${vaultIndex}: ${batchedDeposit.toString()}`);
+        }
 
         // Make sure the user LP token balance before batch submission is 0 for each vault
         expect(
@@ -486,17 +515,18 @@ describe('Mellow Router Test Suite', () => {
           ).toString(),
         ).to.be.eq('0,0');
 
-        // Submit the batch of deposits from the router to the erc20 root vault
-        await ethMellowLpRouter.writeContracts?.mellowRouter.submitBatch(0);
+        // Submit the batch of deposits from the router to the erc20 root vaults
+        for (let vaultIndex = 0; vaultIndex < 2; vaultIndex += 1) {
+          await ethMellowLpRouter.writeContracts?.mellowRouter.submitBatch(vaultIndex, 0);
+        }
 
         // Get the user lp token balance after the router receives it from the erc20 root vault upon batch submission
         const userLpTokenBalance =
           await ethMellowLpRouter.writeContracts?.mellowRouter.getLPTokenBalances(
             userWallet.address,
           );
-        expect(userLpTokenBalance[0]).to.be.closeTo(userLpTokenBalance[1], 1);
-        expect(userLpTokenBalance[0]).to.be.eq('4898906633876018356');
-        expect(userLpTokenBalance[1]).to.be.eq('4898906633876018355');
+        expect(userLpTokenBalance[0]).to.be.eq('5000000000000000000');
+        expect(userLpTokenBalance[1]).to.be.eq('5000000000000000000');
         // eslint-disable-next-line
         console.log('user LP token balance in Router: ', userLpTokenBalance.toString());
 
@@ -517,12 +547,12 @@ describe('Mellow Router Test Suite', () => {
         console.log('Printing tvl list of all erc20 root vaults: ', tvl);
 
         // For each vault
-        expect(tvl[0]).to.be.eq('11673207775126148888');
-        expect(tvl[1]).to.be.eq('11673207775126148888');
+        expect(tvl[0]).to.be.eq('10010000000000000000');
+        expect(tvl[1]).to.be.eq('10010000000000000000');
 
         // For each vault
-        expect(userLpTokenBalance[0]).to.be.eq(BigNumber.from('4898906633876018356'));
-        expect(userLpTokenBalance[1]).to.be.eq(BigNumber.from('4898906633876018355'));
+        expect(userLpTokenBalance[0]).to.be.eq(BigNumber.from('5000000000000000000'));
+        expect(userLpTokenBalance[1]).to.be.eq(BigNumber.from('5000000000000000000'));
       });
     });
   });

--- a/tests/mellowLpRouter.test.ts
+++ b/tests/mellowLpRouter.test.ts
@@ -19,6 +19,7 @@ let localMellowRouterContract: Contract;
 
 const depositAmount = 10; // Set a default 10 ETH constant for use in tests;
 const MellowRouterAddress = '0x704F6E9cB4f7e041CC89B6a49DF8EE2027a55164';
+const vaultIndices: number[] = [0, 1];
 const defaultWeights: number[] = [50, 50]; // default even split between 2 pools
 
 const signer = new Wallet(
@@ -44,7 +45,7 @@ describe('Mellow Router Test Suite', () => {
     });
   };
 
-  beforeEach('Setting up the suite', async () => {
+  beforeEach('Reset Network & Setup Router Contract', async () => {
     await resetNetwork();
 
     localMellowRouterContract = new ethers.Contract(
@@ -62,20 +63,97 @@ describe('Mellow Router Test Suite', () => {
           .addVault((await localMellowRouterContract.getVaults())[0]);
       },
     );
+  });
 
-    ethMellowLpRouter = new MellowLpRouter({
-      mellowRouterAddress: MellowRouterAddress,
-      defaultWeights,
-      provider,
+  describe('Invalid vault initialisation scenarios', async () => {
+    it('Empty vault indices array', async () => {
+      ethMellowLpRouter = new MellowLpRouter({
+        mellowRouterAddress: MellowRouterAddress,
+        vaultIndices: [],
+        defaultWeights,
+        provider,
+      });
+
+      await ethMellowLpRouter.vaultInit();
+      expect(ethMellowLpRouter.vaultInitialized).to.be.eq(false);
     });
 
-    await ethMellowLpRouter.vaultInit();
+    it('Vault indices array not sorted', async () => {
+      ethMellowLpRouter = new MellowLpRouter({
+        mellowRouterAddress: MellowRouterAddress,
+        vaultIndices: [1, 0],
+        defaultWeights,
+        provider,
+      });
 
-    // Initialise the user so the router contract is connected with user to keep track of them as a signer for the deposits
-    await ethMellowLpRouter.userInit(userWallet);
+      await ethMellowLpRouter.vaultInit();
+      expect(ethMellowLpRouter.vaultInitialized).to.be.eq(false);
+    });
+
+    it('Vault indices array contains duplicates', async () => {
+      ethMellowLpRouter = new MellowLpRouter({
+        mellowRouterAddress: MellowRouterAddress,
+        vaultIndices: [0, 0],
+        defaultWeights,
+        provider,
+      });
+
+      await ethMellowLpRouter.vaultInit();
+      expect(ethMellowLpRouter.vaultInitialized).to.be.eq(false);
+    });
+
+    it('Vault indices array contain out-of-range values', async () => {
+      ethMellowLpRouter = new MellowLpRouter({
+        mellowRouterAddress: MellowRouterAddress,
+        vaultIndices: [0, 2],
+        defaultWeights,
+        provider,
+      });
+
+      await ethMellowLpRouter.vaultInit();
+      expect(ethMellowLpRouter.vaultInitialized).to.be.eq(false);
+    });
+
+    it('Weights values are not all integer', async () => {
+      ethMellowLpRouter = new MellowLpRouter({
+        mellowRouterAddress: MellowRouterAddress,
+        vaultIndices: [0, 1],
+        defaultWeights: [49.5, 50.5],
+        provider,
+      });
+
+      await ethMellowLpRouter.vaultInit();
+      expect(ethMellowLpRouter.vaultInitialized).to.be.eq(false);
+    });
+
+    it('Vault indices and default weights arrays do not match', async () => {
+      ethMellowLpRouter = new MellowLpRouter({
+        mellowRouterAddress: MellowRouterAddress,
+        vaultIndices: [0, 1],
+        defaultWeights: [100],
+        provider,
+      });
+
+      await ethMellowLpRouter.vaultInit();
+      expect(ethMellowLpRouter.vaultInitialized).to.be.eq(false);
+    });
   });
 
   describe('Deposit Scenarios', async () => {
+    beforeEach('Setting up the suite', async () => {
+      ethMellowLpRouter = new MellowLpRouter({
+        mellowRouterAddress: MellowRouterAddress,
+        vaultIndices,
+        defaultWeights,
+        provider,
+      });
+
+      await ethMellowLpRouter.vaultInit();
+
+      // Initialise the user so the router contract is connected with user to keep track of them as a signer for the deposits
+      await ethMellowLpRouter.userInit(userWallet);
+    });
+
     it('Check that vault has been initialised correctly', async () => {
       expect(ethMellowLpRouter.vaultInitialized).to.be.eq(true);
       expect(ethMellowLpRouter.readOnlyContracts?.token.address).to.be.eq(
@@ -554,6 +632,64 @@ describe('Mellow Router Test Suite', () => {
         expect(userLpTokenBalance[0]).to.be.eq(BigNumber.from('5000000000000000000'));
         expect(userLpTokenBalance[1]).to.be.eq(BigNumber.from('5000000000000000000'));
       });
+    });
+  });
+
+  describe('Check deposit when weights are expanded', async () => {
+    beforeEach('Adding a third vault', async () => {
+      await withSigner(
+        network,
+        await localMellowRouterContract.owner(),
+        async (routerOwnerSigner) => {
+          await localMellowRouterContract
+            .connect(routerOwnerSigner)
+            .addVault((await localMellowRouterContract.getVaults())[0]);
+        },
+      );
+
+      ethMellowLpRouter = new MellowLpRouter({
+        mellowRouterAddress: MellowRouterAddress,
+        vaultIndices: [0, 2],
+        defaultWeights: [50, 50],
+        provider,
+      });
+
+      await ethMellowLpRouter.vaultInit();
+
+      // Initialise the user so the router contract is connected with user to keep track of them as a signer for the deposits
+      await ethMellowLpRouter.userInit(userWallet);
+    });
+
+    it('Deposit with default weights', async () => {
+      await ethMellowLpRouter.deposit(10);
+
+      // Submit the batch of deposits from the router to the erc20 root vaults
+      for (let vaultIndex = 0; vaultIndex < 3; vaultIndex += 1) {
+        await ethMellowLpRouter.writeContracts?.mellowRouter.submitBatch(vaultIndex, 0);
+      }
+
+      // Get the user lp token balance after the router receives it from the erc20 root vault upon batch submission
+      const userLpTokenBalance =
+        await ethMellowLpRouter.writeContracts?.mellowRouter.getLPTokenBalances(userWallet.address);
+      expect(userLpTokenBalance[0]).to.be.eq('5000000000000000000');
+      expect(userLpTokenBalance[1]).to.be.eq('0');
+      expect(userLpTokenBalance[2]).to.be.eq('5000000000000000000');
+    });
+
+    it('Deposit with custom weights', async () => {
+      await ethMellowLpRouter.deposit(10, [30, 70]);
+
+      // Submit the batch of deposits from the router to the erc20 root vaults
+      for (let vaultIndex = 0; vaultIndex < 3; vaultIndex += 1) {
+        await ethMellowLpRouter.writeContracts?.mellowRouter.submitBatch(vaultIndex, 0);
+      }
+
+      // Get the user lp token balance after the router receives it from the erc20 root vault upon batch submission
+      const userLpTokenBalance =
+        await ethMellowLpRouter.writeContracts?.mellowRouter.getLPTokenBalances(userWallet.address);
+      expect(userLpTokenBalance[0]).to.be.eq('3000000000000000000');
+      expect(userLpTokenBalance[1]).to.be.eq('0');
+      expect(userLpTokenBalance[2]).to.be.eq('7000000000000000000');
     });
   });
 });

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,5 +1,34 @@
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { Network } from 'hardhat/types';
 
 export const fail = (): void => {
   expect(true).to.be.eq(false);
+};
+
+export const addSigner = async (network: Network, address: string): Promise<SignerWithAddress> => {
+  await network.provider.request({
+    method: 'hardhat_impersonateAccount',
+    params: [address],
+  });
+  await network.provider.send('hardhat_setBalance', [address, '0x1000000000000000000']);
+  return ethers.getSigner(address);
+};
+
+const removeSigner = async (network: Network, address: string) => {
+  await network.provider.request({
+    method: 'hardhat_stopImpersonatingAccount',
+    params: [address],
+  });
+};
+
+export const withSigner = async (
+  network: Network,
+  address: string,
+  f: (signer: SignerWithAddress) => Promise<void>,
+): Promise<void> => {
+  const signer = await addSigner(network, address);
+  await f(signer);
+  await removeSigner(network, address);
 };


### PR DESCRIPTION
In order to implement deposit pending, the PR contains 3 main updates:
- commit `feat: adapted code to latest router ABI`
    - The SDK code before this commit used the old ABI of the Router smart contract. This was possible because the actual functionality of the Router object in the SDK did not have exposure to the functions that changed the ABI. However, the tests did have exposure to this.
    - Therefore, the commit updated the ABI and the relevant tests
    - The updated ABI was a prerequisite to the pending deposit functionality.

- commit `feat: refactored code for mixer support`
    - The SDK code before this commit already supported mixer functionality. However, it contained a hard-coded `pivot` mechanism used for the single-vault cards that are currently deployed on the UI.
    - Also, the values in the config file in the UI should have contained a list of weights for all vaults in the Router (which can be potentially long).
    - The code refactors this logic by receiving an additional array of vault indices. For this reason, weights should be expanded to the desired length when passed to the `deposit` function
    - This refactoring also made pending deposit cleaner.

- commit `feat: pending deposit`
    - Having the array of vault indices, we can obtain the pending deposits by passing these indices to the `getBatchedDeposit` function of the Router.
    - Separated deposits into `committed` and `pending`, and their aggregation in `userDeposit` (as before)

Questions:
- shall we use `userTotalDeposit` instead of `userDeposit`?
- shall we add an additional sanity check to the weights array to make sure their sum is 100?
    - PRO: if invalid, we return without having to call the smart contract
    - CONS: if we decide to change the smart contract, we need to change SDK as well
- I've followed existing code by not raising any errors apart from those raised by smart contracts. Instead, I just console logged and returned from function. Is this what we want?