### PR TITLE
fix: pinata get request

### DIFF
--- a/src/entities/communitySbt.ts
+++ b/src/entities/communitySbt.ts
@@ -6,7 +6,7 @@ import { getRootFromSubgraph } from '../utils/communitySbt/getSubgraphRoot';
 import { getProof } from '../utils/communitySbt/merkle-tree';
 import  axios from 'axios';
 import { MULTI_REDEEM_METHOD_ID, REDEEM_METHOD_ID } from '../constants';
-import { decodeBadgeType, decodeMultipleBadgeTypes, geckoEthToUsd, geLeavesIpfsUri, get100KRefereeBenchmark, get2MRefereeBenchmark, getEtherscanURL, getTopBadgeType, toMillis } from '../utils/communitySbt/helpers';
+import { decodeBadgeType, decodeMultipleBadgeTypes, geckoEthToUsd, get100KRefereeBenchmark, get2MRefereeBenchmark, getEtherscanURL, getLeavesIpfsUri, getTopBadgeType, toMillis } from '../utils/communitySbt/helpers';
 import { DateTime } from 'luxon';
 import { getScores, GetScoresArgs } from '../utils/communitySbt/getTopBadges';
 import { getSubgraphBadges } from '../utils/communitySbt/getSubgraphBadges';
@@ -418,7 +418,11 @@ class SBT {
             mapBadges.set(entry.id, entry);
         })
 
-        const data = await axios.get(geLeavesIpfsUri(seasonId, this.badgesCids));
+        const data = await axios.get(getLeavesIpfsUri(seasonId, this.badgesCids), {
+            headers: {
+                'Accept': '*/*'
+            }
+        });
 
         const snasphots : Array<{
                 owner: string

--- a/src/utils/communitySbt/getIpfsLeaves.ts
+++ b/src/utils/communitySbt/getIpfsLeaves.ts
@@ -1,13 +1,17 @@
 import axios from 'axios';
 import { LeafInfo } from '../../entities/communitySbt';
-import { geLeavesIpfsUri } from './helpers';
+import { getLeavesIpfsUri } from './helpers';
 
 export async function createLeaves(
     seasonId: number,
     leavesCids: Array<string>
 ): Promise<Array<LeafInfo>> {
 
-    const data = await axios.get(geLeavesIpfsUri(seasonId, leavesCids));
+    const data = await axios.get(getLeavesIpfsUri(seasonId, leavesCids), {
+        headers: {
+            'Accept': '*/*'
+        }
+    });
 
     const snaphots : Array<{
             owner: string

--- a/src/utils/communitySbt/helpers.ts
+++ b/src/utils/communitySbt/helpers.ts
@@ -88,7 +88,7 @@ export async function geckoEthToUsd(apiKey: string) : Promise<number> {
     return 0;
 };
 
-export function geLeavesIpfsUri(seasonId: number, cidsRecord: Array<string>) : string {
+export function getLeavesIpfsUri(seasonId: number, cidsRecord: Array<string>) : string {
     if (!cidsRecord[seasonId]) {
         throw new Error(`No IPFS CID found for season ${seasonId}`);
     }


### PR DESCRIPTION
Badges from old seasons (i.e. OG) are not showing up because of Pinata get request.
The fix follows: https://knowledge.pinata.cloud/en/articles/6848516-how-to-fix-400-errors-with-dedicated-gateways