### PR TITLE
chore: increment major SDK version because of recent breaking changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voltz-protocol/v1-sdk",
-  "version": "1.24.3",
+  "version": "2.0.0",
   "description": "A TypeScript wrapper for the Voltz smart contract",
   "main": "dist/index.js",
   "types": "dist/types",


### PR DESCRIPTION
Not sure yet why the bot didn't do this.