### PR TITLE
fix: leaderboard and OG claiming

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -71,4 +71,5 @@ export const GOERLI_ONE_HUNDRED_THOUSAND = 1;
 export const GOERLI_TWO_MILLON = 200;
 
 export const ONE_HOUR_IN_MS = 60 * 60 * 1000;
+export const ONE_DAY_IN_SECONDS = 60 * 60 * 24;
 export const DEPOSIT_WINDOW = 48 * ONE_HOUR_IN_MS;

--- a/src/entities/communitySbt.ts
+++ b/src/entities/communitySbt.ts
@@ -5,7 +5,7 @@ import { createLeaves } from '../utils/communitySbt/getIpfsLeaves';
 import { getRootFromSubgraph } from '../utils/communitySbt/getSubgraphRoot';
 import { getProof } from '../utils/communitySbt/merkle-tree';
 import  axios from 'axios';
-import { MULTI_REDEEM_METHOD_ID, REDEEM_METHOD_ID } from '../constants';
+import { MULTI_REDEEM_METHOD_ID, ONE_DAY_IN_SECONDS, ONE_HOUR_IN_MS, REDEEM_METHOD_ID } from '../constants';
 import { decodeBadgeType, decodeMultipleBadgeTypes, get100KRefereeBenchmark, get2MRefereeBenchmark, getEtherscanURL, getLeavesIpfsUri, getSelectedSeasonBadgesUrl, getTopBadgeType, toMillis } from '../utils/communitySbt/helpers';
 import { DateTime } from 'luxon';
 import { getScores, GetScoresArgs } from '../utils/communitySbt/getTopBadges';
@@ -463,7 +463,7 @@ class SBT {
                 subgraphSnapshots.push({
                     id: id,
                     badgeType: entry.badgeType.toString(),
-                    awardedTimestampMs: mapBadges.get(id)?.awardedTimestampMs || toMillis(seasonEnd),
+                    awardedTimestampMs: mapBadges.get(id)?.awardedTimestampMs || toMillis(seasonEnd - ONE_DAY_IN_SECONDS),
                     mintedTimestampMs: mapBadges.get(id)?.mintedTimestampMs || undefined,
                 })
             }

--- a/src/utils/communitySbt/getTopBadges.ts
+++ b/src/utils/communitySbt/getTopBadges.ts
@@ -59,8 +59,8 @@ export async function getScores({
     isLP
 } : GetScoresArgs): Promise<Record<string, number>> {
     const activityQuery = `
-        query( $skipCount: Int) {
-            wallets(first: 1000, skip: $skipCount) {
+        query( $lastId: String) {
+            wallets(first: 1000, where: {id_gt: $lastId}) {
                 id
                 positions {
                     amm {
@@ -100,15 +100,14 @@ export async function getScores({
   
     const scores: Record<string, number> = {};
   
-    let skip = 0;
+    let lastId = "0";
     while (true) {
         const data = await client.query({
             query: gql(activityQuery),
             variables: {
-                skipCount: skip,
+              lastId: lastId,
             },
         });
-      skip += 1000;
 
       const wallets = data?.data?.wallets ?? [];
   
@@ -148,6 +147,7 @@ export async function getScores({
         if (score > 0 && !ignoredWalletIds[wallet.id.toLowerCase()]) {
             scores[wallet.id] = score;
         }
+        lastId = wallet.id;
       }
   
       if (wallets < 1000) {


### PR DESCRIPTION
- Adapting subgraph query for high data volumes (remove skip).
- Modify badge awarded timestamp for badges that are no longer in subgraph. Adding 1-day buffer from the season end.