### PR TITLE
fix: pinata get headers

### DIFF
--- a/src/entities/communitySbt.ts
+++ b/src/entities/communitySbt.ts
@@ -436,7 +436,7 @@ class SBT {
 
     const data = await axios.get(getLeavesIpfsUri(seasonId, this.badgesCids), {
       headers: {
-        Accept: '*/*',
+        Accept: 'text/plain',
       },
     });
 

--- a/src/utils/communitySbt/getIpfsLeaves.ts
+++ b/src/utils/communitySbt/getIpfsLeaves.ts
@@ -8,7 +8,7 @@ export async function createLeaves(
 ): Promise<Array<LeafInfo>> {
   const data = await axios.get(getLeavesIpfsUri(seasonId, leavesCids), {
     headers: {
-      Accept: '*/*',
+      Accept: 'text/plain',
     },
   });
 


### PR DESCRIPTION
Instead of using headers wildcard, use 'text/plain' to avoid queries being blocked by anti-virus
